### PR TITLE
[ADHOC] fix(githubclt): Handle 'no new commits' error during branch update

### DIFF
--- a/internal/githubclt/client.go
+++ b/internal/githubclt/client.go
@@ -201,6 +201,11 @@ func (clt *Client) UpdateBranch(ctx context.Context, owner, repo string, pullReq
 
 					return nil, goorderr.NewRetryableAnytimeError(err)
 				}
+
+				if strings.Contains(respErr.Message, "no new commits on the base branch") {
+					logger.Debug("branch is already up-to-date with base branch, considering update successful")
+					return &UpdateBranchResult{HeadCommitID: prHEADSHA}, nil
+				}
 			}
 		}
 

--- a/internal/githubclt/client_test.go
+++ b/internal/githubclt/client_test.go
@@ -3,10 +3,13 @@ package githubclt
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/google/go-github/v67/github"
 	"github.com/simplesurance/directorius/internal/goorderr"
 
 	"github.com/shurcooL/githubv4"
@@ -43,4 +46,48 @@ func TestWrapRetryableErrorsGraphqlWithNonStatusErr(t *testing.T) {
 	err := errors.New("error")
 	wrappedErr := (&Client{}).wrapGraphQLRetryableErrors(err)
 	assert.Equal(t, err, wrappedErr)
+}
+
+func TestUpdateBranch_SuccessWhenBranchIsAlreadyUpToDate(t *testing.T) {
+	t.Cleanup(zap.ReplaceGlobals(zaptest.NewLogger(t).Named(t.Name())))
+
+	mux := http.NewServeMux()
+
+	// Mock for the initial PRIsUptodate check, which gets the pull request.
+	// We return "mergeable_state": "behind" to ensure the client proceeds to the update step.
+	mux.HandleFunc("/repos/owner/repo/pulls/1", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		fmt.Fprint(w, `{"head": {"sha": "test-sha"}, "base": {"ref": "main"}, "mergeable_state": "behind", "state": "open"}`)
+	})
+
+	// Mock for the update-branch call itself.
+	// This is the core of the test: we simulate the specific 422 error that should be handled as a success.
+	mux.HandleFunc("/repos/owner/repo/pulls/1/update-branch", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"message": "There are no new commits on the base branch."}`)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// Create a new github client that uses the test server
+	restClient := github.NewClient(srv.Client())
+	url, err := url.Parse(srv.URL + "/")
+	require.NoError(t, err)
+	restClient.BaseURL = url
+
+	clt := &Client{
+		restClt:    restClient,
+		graphQLClt: nil, // Not used in this code path
+		logger:     zap.L(),
+	}
+
+	result, err := clt.UpdateBranch(context.Background(), "owner", "repo", 1)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "test-sha", result.HeadCommitID)
+	assert.False(t, result.Changed, "Result.Changed should be false")
+	assert.False(t, result.Scheduled, "Result.Scheduled should be false")
 }

--- a/internal/githubclt/client_test.go
+++ b/internal/githubclt/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v67/github"
+
 	"github.com/simplesurance/directorius/internal/goorderr"
 
 	"github.com/shurcooL/githubv4"
@@ -56,14 +57,14 @@ func TestUpdateBranch_SuccessWhenBranchIsAlreadyUpToDate(t *testing.T) {
 	// Mock for the initial PRIsUptodate check, which gets the pull request.
 	// We return "mergeable_state": "behind" to ensure the client proceeds to the update step.
 	mux.HandleFunc("/repos/owner/repo/pulls/1", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
 		fmt.Fprint(w, `{"head": {"sha": "test-sha"}, "base": {"ref": "main"}, "mergeable_state": "behind", "state": "open"}`)
 	})
 
 	// Mock for the update-branch call itself.
 	// This is the core of the test: we simulate the specific 422 error that should be handled as a success.
 	mux.HandleFunc("/repos/owner/repo/pulls/1/update-branch", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, http.MethodPut, r.Method)
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		fmt.Fprint(w, `{"message": "There are no new commits on the base branch."}`)
 	})


### PR DESCRIPTION
When calling the GitHub API to update a pull request branch, a race condition can occur. An initial check may determine the branch is behind, but by the time the actual update request is sent, the branch may already be in sync with its base.

In this scenario, the GitHub API returns a `422 Unprocessable Entity` error with the message "no new commits on the base branch.". Previously, this was treated as a generic failure, causing the operation to error out.

This change makes the client more robust by correctly interpreting this specific API response. The `UpdateBranch` function now considers this error a successful, no-op outcome, returning a success result indicating that the branch is already up-to-date.

A new unit test is added to simulate this exact API response and verify that it is handled gracefully as a success.
