### PR TITLE
chore(deps): Update Go to 1.24 and golangci-lint to v2.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Check out code
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.62
+          version: v2.3.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - copyloopvar
@@ -7,10 +8,7 @@ linters:
     - errorlint
     - gocritic
     - godox
-    - gofumpt
-    - goimports
     - goprintffuncname
-    - gosimple
     - govet
     - ineffassign
     - loggercheck
@@ -20,19 +18,39 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - tenv
     - testifylint
-    - typecheck
     - unconvert
     - unused
     - usestdlibvars
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/simplesurance/directorius
-  godox:
-    keywords:
-      - FIXME
-  gofumpt:
-    module-path: github.com/simplesurance/directorius
-    extra-rules: true
+  settings:
+    godox:
+      keywords:
+        - FIXME
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      module-path: github.com/simplesurance/directorius
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/simplesurance/directorius
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/mergequeue/httplistdata.go
+++ b/internal/mergequeue/httplistdata.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/simplesurance/directorius/internal/mergequeue/pages/types"
+	"github.com/simplesurance/directorius/internal/mergequeue/pages/pagestypes"
 )
 
-func (a *Coordinator) httpListData() *types.ListData {
-	result := types.ListData{
+func (a *Coordinator) httpListData() *pagestypes.ListData {
+	result := pagestypes.ListData{
 		CreatedAt:             time.Now(),
 		PriorityChangePostURL: handlerPriorityUpdatePath,
 		SuspendResumePostURL:  handlerSuspendResumePath,
@@ -45,7 +45,7 @@ func (a *Coordinator) httpListData() *types.ListData {
 	}
 
 	for baseBranch, queue := range a.queues {
-		queueData := types.Queue{
+		queueData := pagestypes.Queue{
 			RepositoryOwner: baseBranch.RepositoryOwner,
 			Repository:      baseBranch.Repository,
 			BaseBranch:      baseBranch.Branch,
@@ -66,8 +66,8 @@ func (a *Coordinator) httpListData() *types.ListData {
 	return &result
 }
 
-func toPagesPullRequests(prs []*PullRequest) []*types.PullRequest {
-	result := make([]*types.PullRequest, 0, len(prs))
+func toPagesPullRequests(prs []*PullRequest) []*pagestypes.PullRequest {
+	result := make([]*pagestypes.PullRequest, 0, len(prs))
 	for i, pr := range prs {
 		result = append(result, toPagesPullRequest(pr, i == 0))
 	}
@@ -75,22 +75,22 @@ func toPagesPullRequests(prs []*PullRequest) []*types.PullRequest {
 	return result
 }
 
-func toPagesPullRequest(pr *PullRequest, isFirst bool) *types.PullRequest {
-	return &types.PullRequest{
+func toPagesPullRequest(pr *PullRequest, isFirst bool) *pagestypes.PullRequest {
+	return &pagestypes.PullRequest{
 		Number:   strconv.Itoa(pr.Number),
-		Priority: types.PRPriorityOptions(pr.Number, pr.Priority.Load()),
-		Link: &types.Link{
+		Priority: pagestypes.PRPriorityOptions(pr.Number, pr.Priority.Load()),
+		Link: &pagestypes.Link{
 			Text: fmt.Sprintf("%s (#%d)", pr.Title, pr.Number),
 			URL:  pr.Link,
 		},
-		Author: &types.Link{
+		Author: &pagestypes.Link{
 			Text: pr.Author,
 			URL:  urlJoin("https://github.com", pr.Author),
 		},
-		EnqueuedSince:      types.TimeSince(pr.EnqueuedAt),
-		InActiveQueueSince: types.TimeSince(pr.InActiveQueueSince()),
+		EnqueuedSince:      pagestypes.TimeSince(pr.EnqueuedAt),
+		InActiveQueueSince: pagestypes.TimeSince(pr.InActiveQueueSince()),
 		Suspensions:        pr.SuspendCount.Load(),
-		Status:             types.PRStatus(isFirst),
+		Status:             pagestypes.PRStatus(isFirst),
 	}
 }
 

--- a/internal/mergequeue/httpservice.go
+++ b/internal/mergequeue/httpservice.go
@@ -10,10 +10,8 @@ import (
 	"path"
 	"strconv"
 
-	_ "embed" // used to embed html templates and static docs
-
 	"github.com/simplesurance/directorius/internal/logfields"
-	"github.com/simplesurance/directorius/internal/mergequeue/pages/types"
+	"github.com/simplesurance/directorius/internal/mergequeue/pages/pagestypes"
 
 	"go.uber.org/zap"
 )
@@ -200,7 +198,7 @@ func formToPriorityUpdates(form url.Values) (*PRPriorityUpdates, error) {
 			return nil, fmt.Errorf("form key %q is not a pull request number", k)
 		}
 		val := vals[0]
-		if val == types.OptionValueSelected {
+		if val == pagestypes.OptionValueSelected {
 			// priority has not been modified
 			continue
 		}

--- a/internal/mergequeue/pages/pagestypes/general.go
+++ b/internal/mergequeue/pages/pagestypes/general.go
@@ -1,4 +1,4 @@
-package types
+package pagestypes
 
 import "time"
 

--- a/internal/mergequeue/pages/pagestypes/listdata.go
+++ b/internal/mergequeue/pages/pagestypes/listdata.go
@@ -1,4 +1,4 @@
-package types
+package pagestypes
 
 import "time"
 

--- a/internal/mergequeue/pages/pagestypes/pullrequest.go
+++ b/internal/mergequeue/pages/pagestypes/pullrequest.go
@@ -1,4 +1,4 @@
-package types
+package pagestypes
 
 import "strconv"
 

--- a/internal/mergequeue/pages/pagestypes/queue.go
+++ b/internal/mergequeue/pages/pagestypes/queue.go
@@ -1,4 +1,4 @@
-package types
+package pagestypes
 
 type Queue struct {
 	RepositoryOwner string


### PR DESCRIPTION
This commit updates the Go version from 1.23 to 1.24 in the CI workflows. It also upgrades golangci-lint from v1.62 to v2.3.0 and its corresponding GitHub Action from v6 to v8.

The major version bump of golangci-lint required several adjustments to maintain compatibility and pass the new linting checks:

- The `.golangci.yml` configuration is updated to the new `version: "2"` format. In this format, formatters like `gofumpt` and `goimports` are configured in a dedicated `formatters` section instead of as linters.

- The updated linters (specifically staticcheck's ST1002 rule) now disallow using `types` as a package name because it shadows the built-in keyword. To resolve this, the package `internal/mergequeue/pages/types` has been renamed to `internal/mergequeue/pages/pagestypes`. This is a purely structural refactoring with no functional changes.